### PR TITLE
Add configuration & token generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,16 @@ TODO...
 
 ### Configuration
 
-TODO...
+By default, the module is configured to read the configuration from ENV variables.
+
+Currently, the following ENV variables are supported:
+
+| ENV variable | Description | Default value |
+| ------------ | ----------- |-------|
+| ANONYMOUS_CODES_DEFAULT_TOKEN_LENGTH | The length of the codes generated if using the default token generator | `10` |
+| ANONYMOUS_CODES_TOKEN_STYLE | The type of codes generated if using the default token generator (options are `alphanumeric`, `numeric`). (note that "numeric" still returns a string, just only formed by number chars) | `alphanumeric` |
+
+It is also possible to configure the module using the `decidim-anonymous_codes` initializer:
 
 Create an initializer (for instance `config/initializers/anonymous_codes.rb`) and configure the following:
 
@@ -46,6 +55,14 @@ Create an initializer (for instance `config/initializers/anonymous_codes.rb`) an
 # config/initializers/anonymous_codes.rb
 
 Decidim::AnonymousCodes.configure do |config|
+  # The length of the codes generated if using the default alphanumeric generator
+  config.default_token_length = 10
+
+  # The generator to use for the codes (defaults to an alphanumeric uppercase string of length "default_token_length")
+  # if you customize this, the default_token_length will be ignored
+  def self.token_generator
+  	SecureRandom.hex(25)
+  end
 end
 ```
 

--- a/lib/decidim/anonymous_codes.rb
+++ b/lib/decidim/anonymous_codes.rb
@@ -6,5 +6,23 @@ module Decidim
   # This namespace holds the logic of the `decidim-anonymous_codes` module.
   module AnonymousCodes
     include ActiveSupport::Configurable
+
+    config_accessor :default_token_length do
+      ENV.fetch("ANONYMOUS_CODES_DEFAULT_TOKEN_LENGTH", 10).to_i
+    end
+
+    config_accessor :token_style do
+      ENV.fetch("ANONYMOUS_CODES_TOKEN_STYLE", "alphanumeric")
+    end
+
+    def self.token_generator(length = nil)
+      length ||= AnonymousCodes.default_token_length
+      case AnonymousCodes.token_style
+      when "numeric"
+        SecureRandom.random_number(10**length).to_s.rjust(length, "0")
+      else
+        SecureRandom.alphanumeric(length).upcase
+      end
+    end
   end
 end

--- a/spec/lib/anonymous_codes_spec.rb
+++ b/spec/lib/anonymous_codes_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe AnonymousCodes do
+    subject { described_class }
+    let(:token_length) { 10 }
+    let(:token_style) { "alphanumeric" }
+
+    before do
+      allow(AnonymousCodes).to receive(:default_token_length).and_return(token_length)
+      allow(AnonymousCodes).to receive(:token_style).and_return(token_style)
+    end
+
+    it "has a token generator" do
+      expect(subject.token_generator.size).to eq(10)
+      expect(subject.token_generator).to match(/\A\w+\z/)
+    end
+
+    context "when configuring the token length" do
+      let(:token_length) { 5 }
+
+      it "has a token generator" do
+        expect(subject.token_generator.size).to eq(5)
+      end
+    end
+
+    context "when configuring the token style" do
+      let(:token_style) { "numeric" }
+
+      it "has a token generator" do
+        expect(subject.token_generator.size).to eq(10)
+        expect(subject.token_generator).to match(/\A\d+\z/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a default, configurable token generator.

Usage:
```ruby
random_token = Decidim::AnonymousCodes.token_generator
```