### PR TITLE
Restrict surveys access if code required

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     decidim-anonymous_codes (1.0)
       decidim-admin (>= 0.27.0, < 0.28)
       decidim-core (>= 0.27.0, < 0.28)
+      decidim-forms (>= 0.27.0, < 0.28)
       decidim-surveys (>= 0.27.0, < 0.28)
       deface (>= 1.9.0)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require "decidim/dev/common_rake"
 require "fileutils"
+require "decidim/dev/common_rake"
+require "decidim/anonymous_codes/engine"
 
 def install_module(path)
   Dir.chdir(path) do
@@ -13,6 +14,7 @@ end
 def seed_db(path)
   Dir.chdir(path) do
     system("bundle exec rake db:seed")
+    system("bundle exec rake decidim_anonymous_codes:db:seed")
   end
 end
 

--- a/app/controllers/concerns/decidim/anonymous_codes/surveys_controller_override.rb
+++ b/app/controllers/concerns/decidim/anonymous_codes/surveys_controller_override.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AnonymousCodes
+    module SurveysControllerOverride
+      extend ActiveSupport::Concern
+
+      included do
+        before_action do
+          unless token_groups.any? && current_token.present?
+            flash.now[:alert] = I18n.t("decidim.anonymous_codes.invalid_code") if params.has_key?(:token)
+            render "decidim/anonymous_codes/surveys/code_required"
+          end
+        end
+
+        private
+
+        def token_groups
+          @token_groups ||= Decidim::AnonymousCodes::Group.where(resource: survey)
+        end
+
+        def current_token
+          @current_token ||= Decidim::AnonymousCodes::Token.where(group: token_groups).find_by(token: token_param)
+        end
+
+        def token_param
+          @token_param ||= begin
+            session[:anonymous_codes_token] = params[:token] if params.has_key?(:token)
+            session[:anonymous_codes_token]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/decidim/anonymous_codes/surveys_controller_override.rb
+++ b/app/controllers/concerns/decidim/anonymous_codes/surveys_controller_override.rb
@@ -7,8 +7,18 @@ module Decidim
 
       included do
         before_action do
-          unless token_groups.any? && current_token.present?
-            flash.now[:alert] = I18n.t("decidim.anonymous_codes.invalid_code") if params.has_key?(:token)
+          next unless current_settings.allow_answers? && survey.open?
+
+          if token_groups.any?
+            next if current_token&.available?
+
+            if current_token.blank?
+              flash.now[:alert] = I18n.t("decidim.anonymous_codes.invalid_code") if params.has_key?(:token)
+            elsif current_token.used?
+              flash.now[:alert] = I18n.t("decidim.anonymous_codes.used_code")
+            elsif current_token.expired?
+              flash.now[:alert] = I18n.t("decidim.anonymous_codes.expired_code")
+            end
             render "decidim/anonymous_codes/surveys/code_required"
           end
         end
@@ -16,7 +26,7 @@ module Decidim
         private
 
         def token_groups
-          @token_groups ||= Decidim::AnonymousCodes::Group.where(resource: survey)
+          @token_groups ||= Decidim::AnonymousCodes::Group.where(resource: survey, active: true)
         end
 
         def current_token

--- a/app/models/decidim/anonymous_codes/token.rb
+++ b/app/models/decidim/anonymous_codes/token.rb
@@ -15,6 +15,8 @@ module Decidim
       has_many :answers, through: :token_resources, source_type: "Decidim::Forms::Answer", source: :resource
 
       delegate :active?, to: :group
+      validates :token, presence: true
+      validates :token, uniqueness: { scope: [:group] }
 
       def available?
         !used? && !expired? && active?

--- a/app/models/decidim/anonymous_codes/token.rb
+++ b/app/models/decidim/anonymous_codes/token.rb
@@ -12,6 +12,20 @@ module Decidim
 
       belongs_to :group, class_name: "Decidim::AnonymousCodes::Group"
       belongs_to :resource, polymorphic: true, optional: true
+
+      delegate :active?, to: :group
+
+      def available?
+        !used? && !expired? && active?
+      end
+
+      def used?
+        usage_count.to_i >= group.max_reuses.to_i
+      end
+
+      def expired?
+        group.expires_at.present? && group.expires_at < Time.current
+      end
     end
   end
 end

--- a/app/models/decidim/anonymous_codes/token.rb
+++ b/app/models/decidim/anonymous_codes/token.rb
@@ -10,8 +10,9 @@ module Decidim
         throw(:abort) if usage_count.positive?
       end
 
-      belongs_to :group, class_name: "Decidim::AnonymousCodes::Group"
-      belongs_to :resource, polymorphic: true, optional: true
+      belongs_to :group, class_name: "Decidim::AnonymousCodes::Group", counter_cache: true
+      has_many :token_resources, class_name: "Decidim::AnonymousCodes::TokenResource", dependent: :destroy
+      has_many :answers, through: :token_resources, source_type: "Decidim::Forms::Answer", source: :resource
 
       delegate :active?, to: :group
 

--- a/app/models/decidim/anonymous_codes/token_resource.rb
+++ b/app/models/decidim/anonymous_codes/token_resource.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AnonymousCodes
+    class TokenResource < ApplicationRecord
+      self.table_name = :decidim_anonymous_codes_token_resources
+
+      belongs_to :token, class_name: "Decidim::AnonymousCodes::Token", counter_cache: :usage_count
+      belongs_to :resource, polymorphic: true
+
+      validate :max_uses_not_exceeded
+      validate :valid_parent_questionnaire
+
+      private
+
+      def max_uses_not_exceeded
+        return unless token.usage_count >= token.group.max_reuses
+
+        errors.add(:base, :max_uses_exceeded)
+      end
+
+      def valid_parent_questionnaire
+        return unless resource.try(:questionnaire) != token.group.resource.try(:questionnaire)
+
+        errors.add(:base, :invalid_questionnaire)
+      end
+    end
+  end
+end

--- a/app/views/decidim/anonymous_codes/surveys/code_required.html.erb
+++ b/app/views/decidim/anonymous_codes/surveys/code_required.html.erb
@@ -1,0 +1,50 @@
+<% add_decidim_meta_tags({
+  title: translated_attribute(questionnaire.title),
+  description: translated_attribute(questionnaire.description),
+}) %>
+
+<%= render partial: "decidim/shared/component_announcement" if current_component.manifest_name == "surveys" %>
+
+<div class="row columns">
+  <h2 class="section-heading"><%= translated_attribute questionnaire.title %></h2>
+  <div class="row">
+    <div class="columns large-6 medium-centered lead">
+      <%= decidim_sanitize_editor_admin translated_attribute questionnaire.description %>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="columns large-6 medium-centered">
+    <div class="card">
+      <div class="card__content">
+        <% unless questionnaire_for.try(:component)&.try(:published?) %>
+          <div class="section">
+            <div class="callout warning">
+              <p><%= t("questionnaire_not_published.body", scope: "decidim.forms.questionnaires.show") %></p>
+            </div>
+          </div>
+        <% end %>
+
+        <div class="section">
+          <div class="callout warning">
+            <h3 class="heading4"><%= t(".title") %></h3>
+            <p><%= t(".body") %></p>
+          </div>
+          <fi3eldset class="field">
+            <label class="field__label" for="code"><%= t(".label") %></label>
+            <div class="field__input">
+              <form method="get">
+                <%= text_field_tag :token, nil, class: "input", required: true %>
+                <button type="submit" class="button"><%= t(".submit") %></button>
+              </form>
+            </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% content_for :js_content do %>
+  <%= javascript_pack_tag "decidim_forms" %>
+<% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -6,6 +6,7 @@ locales: [en]
 data:
   external:
     - "<%= %x[bundle info decidim-core --path].chomp %>/config/locales/%{locale}.yml"
+    - "<%= %x[bundle info decidim-forms --path].chomp %>/config/locales/%{locale}.yml"
 ignore_unused:
 
 ignore_missing:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,10 +15,13 @@ en:
               still apply if you choose to use this option.
             groups: 'Edit groups:'
             new_group: "\U0001F449 Create answer codes here"
+      expired_code: The introduced code has expired. Please try again.
       invalid_code: The introduced code is invalid. Please try again.
       surveys:
         code_required:
-          title: Form restricted
-          body: This form can only be accessed using a valid code. If you have a valid code, please enter it below.
+          body: This form can only be accessed using a valid code. If you have a valid
+            code, please enter it below.
           label: Code
           submit: Continue
+          title: Form restricted
+      used_code: The introduced code has already been used. Please try again.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,3 +15,10 @@ en:
               still apply if you choose to use this option.
             groups: 'Edit groups:'
             new_group: "\U0001F449 Create answer codes here"
+      invalid_code: The introduced code is invalid. Please try again.
+      surveys:
+        code_required:
+          title: Form restricted
+          body: This form can only be accessed using a valid code. If you have a valid code, please enter it below.
+          label: Code
+          submit: Continue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,12 @@
 ---
 en:
+  activerecord:
+    errors:
+      models:
+        decidim/anonymous_codes/token_resource:
+          invalid_questionnaire: The attached answer belongs to a different questionnaire.
+          max_uses_exceeded: The code has already been used the maximum number of
+            times.
   decidim:
     anonymous_codes:
       admin:

--- a/db/migrate/20240403091336_create_decidim_anonymous_codes_groups.rb
+++ b/db/migrate/20240403091336_create_decidim_anonymous_codes_groups.rb
@@ -8,6 +8,7 @@ class CreateDecidimAnonymousCodesGroups < ActiveRecord::Migration[6.1]
       t.datetime :expires_at
       t.boolean :active, default: true, null: false
       t.integer :max_reuses, default: 1, null: false
+      t.integer :tokens_count, default: 0, null: false
       t.references :resource, polymorphic: true, null: true, index: { name: "decidim_anonymous_codes_groups_on_resource" }
       t.references :decidim_organization, null: false, foreign_key: true, index: { name: "decidim_anonymous_codes_groups_on_organization" }
 

--- a/db/migrate/20240403091356_create_decidim_anonymous_codes_tokens.rb
+++ b/db/migrate/20240403091356_create_decidim_anonymous_codes_tokens.rb
@@ -7,7 +7,6 @@ class CreateDecidimAnonymousCodesTokens < ActiveRecord::Migration[6.1]
       t.integer :usage_count, default: 0, null: false
 
       t.references :group, null: false, index: { name: "decidim_anonymous_codes_tokens_on_group" }
-      t.references :resource, polymorphic: true, null: true, index: { name: "decidim_anonymous_codes_tokens_on_resource" }
       t.timestamps
     end
   end

--- a/db/migrate/20240403091356_create_decidim_anonymous_codes_tokens.rb
+++ b/db/migrate/20240403091356_create_decidim_anonymous_codes_tokens.rb
@@ -7,6 +7,7 @@ class CreateDecidimAnonymousCodesTokens < ActiveRecord::Migration[6.1]
       t.integer :usage_count, default: 0, null: false
 
       t.references :group, null: false, index: { name: "decidim_anonymous_codes_tokens_on_group" }
+      t.index [:token, :group_id], name: "index_anonymous_codes_token_group_uniqueness", unique: true
       t.timestamps
     end
   end

--- a/db/migrate/20240403091376_create_decidim_anonymous_codes_token_resources.rb
+++ b/db/migrate/20240403091376_create_decidim_anonymous_codes_token_resources.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateDecidimAnonymousCodesTokenResources < ActiveRecord::Migration[6.1]
+  def change
+    create_table :decidim_anonymous_codes_token_resources do |t|
+      t.references :token, null: false, index: { name: "decidim_anonymous_codes_token_resources_on_token" }
+      t.references :resource, polymorphic: true, null: false, index: { name: "decidim_anonymous_codes_token_resources_on_resource" }
+      t.timestamps
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,43 +23,25 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
         puts "ERROR: Component #{component.id} not updated"
       end
     end
-  end
 
-  [survey1, survey2].each do |survey|
-    if survey.component.participatory_space.respond_to? :steps
-      steps = survey.component.participatory_space.steps.pluck(:id)
-      steps.each do |step|
-        survey.component.attributes["settings"]["steps"] = { step.to_s => { "allow_answers" => true, "allow_unregistered" => true } }
-      end
-    else
-      survey.component.attributes["settings"]["default_step"] = { "allow_answers" => true, "allow_unregistered" => true }
+    survey = Decidim::Surveys::Survey.find_by(component: component)
+    next unless survey
+
+    group = Decidim.traceability.create!(
+      Decidim::AnonymousCodes::Group,
+      admin,
+      {
+        title: { en: "Group for Survey #{survey.id}" },
+        organization: organization,
+        expires_at: 1.week.from_now,
+        active: rand(2).zero?,
+        max_reuses: rand(3),
+        resource: survey
+      },
+      visibility: "admin-only"
+    )
+    rand(25).times do
+      Decidim::AnonymousCodes::Token.create!(token: Decidim::AnonymousCodes.token_generator, group: group)
     end
-    survey.save!
-  end
-
-  group1 = Decidim::AnonymousCodes::Group.create!(
-    title: { en: "First Group" },
-    organization: organization,
-    expires_at: 1.week.from_now,
-    active: true,
-    max_reuses: 1,
-    resource: survey1
-  )
-
-  group2 = Decidim::AnonymousCodes::Group.create!(
-    title: { en: "Second Group" },
-    organization: organization,
-    expires_at: 1.week.from_now,
-    active: true,
-    max_reuses: 1,
-    resource: survey2
-  )
-
-  5.times do
-    Decidim::AnonymousCodes::Token.create!(token: Decidim::AnonymousCodes.token_generator, usage_count: 0, group: group1)
-  end
-
-  25.times do
-    Decidim::AnonymousCodes::Token.create!(token: Decidim::AnonymousCodes.token_generator, usage_count: 0, group: group2)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,38 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
   print "Creating seeds for decidim_anonymous_codes...\n" unless Rails.env.test?
 
   organization = Decidim::Organization.first
+  admin = Decidim::User.where(admin: true).first
+  participatory_processes = Decidim::ParticipatoryProcess.where(organization: organization)
+  survey_components = Decidim::Component.where(manifest_name: "surveys", participatory_space: participatory_processes)
+  survey_components.each do |component|
+    form = OpenStruct.new(name: component.name, weight: component.weight, settings: component.settings, default_step_settings: component.default_step_settings,
+                          step_settings: component.step_settings)
+    form.step_settings.each do |key, _value|
+      form.step_settings[key]["allow_answers"] = true
+      form.step_settings[key]["allow_unregistered"] = true
+    end
+    Decidim::Admin::UpdateComponent.call(form, component, admin) do
+      on(:ok) do
+        puts "Component #{component.id} updated"
+      end
+
+      on(:invalid) do
+        puts "ERROR: Component #{component.id} not updated"
+      end
+    end
+  end
+
+  [survey1, survey2].each do |survey|
+    if survey.component.participatory_space.respond_to? :steps
+      steps = survey.component.participatory_space.steps.pluck(:id)
+      steps.each do |step|
+        survey.component.attributes["settings"]["steps"] = { step.to_s => { "allow_answers" => true, "allow_unregistered" => true } }
+      end
+    else
+      survey.component.attributes["settings"]["default_step"] = { "allow_answers" => true, "allow_unregistered" => true }
+    end
+    survey.save!
+  end
 
   group1 = Decidim::AnonymousCodes::Group.create!(
     title: { en: "First Group" },
@@ -11,7 +43,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
     expires_at: 1.week.from_now,
     active: true,
     max_reuses: 1,
-    resource: Decidim::Surveys::Survey.first
+    resource: survey1
   )
 
   group2 = Decidim::AnonymousCodes::Group.create!(
@@ -20,7 +52,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
     expires_at: 1.week.from_now,
     active: true,
     max_reuses: 1,
-    resource: Decidim::Surveys::Survey.second
+    resource: survey2
   )
 
   5.times do

--- a/decidim-anonymous_codes.gemspec
+++ b/decidim-anonymous_codes.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "decidim-admin", Decidim::AnonymousCodes::COMPAT_DECIDIM_VERSION
   spec.add_dependency "decidim-core", Decidim::AnonymousCodes::COMPAT_DECIDIM_VERSION
+  spec.add_dependency "decidim-forms", Decidim::AnonymousCodes::COMPAT_DECIDIM_VERSION
   spec.add_dependency "decidim-surveys", Decidim::AnonymousCodes::COMPAT_DECIDIM_VERSION
   spec.add_dependency "deface", ">= 1.9.0"
 

--- a/lib/decidim/anonymous_codes/engine.rb
+++ b/lib/decidim/anonymous_codes/engine.rb
@@ -9,9 +9,9 @@ module Decidim
       isolate_namespace Decidim::AnonymousCodes
 
       initializer "decidim_anonymous_codes.overrides", after: "decidim.action_controller" do
-        # config.to_prepare do
-
-        # end
+        config.to_prepare do
+          Decidim::Surveys::SurveysController.include(Decidim::AnonymousCodes::SurveysControllerOverride)
+        end
       end
 
       initializer "decidim-anonymous_codes.webpacker.assets_path" do

--- a/lib/decidim/anonymous_codes/test/factories.rb
+++ b/lib/decidim/anonymous_codes/test/factories.rb
@@ -15,7 +15,9 @@ FactoryBot.define do
     group { create(:anonymous_codes_group) }
 
     trait :used do
-      token_resources { [create(:anonymous_codes_token_resource)] }
+      after(:create) do |object|
+        object.token_resources << create(:anonymous_codes_token_resource, token: object)
+      end
     end
   end
 

--- a/lib/decidim/anonymous_codes/test/factories.rb
+++ b/lib/decidim/anonymous_codes/test/factories.rb
@@ -12,7 +12,15 @@ FactoryBot.define do
 
   factory :anonymous_codes_token, class: "Decidim::AnonymousCodes::Token" do
     token { Decidim::AnonymousCodes.token_generator }
-    usage_count { 0 }
     group { create(:anonymous_codes_group) }
+
+    trait :used do
+      token_resources { [create(:anonymous_codes_token_resource)] }
+    end
+  end
+
+  factory :anonymous_codes_token_resource, class: "Decidim::AnonymousCodes::TokenResource" do
+    token { create(:anonymous_codes_token) }
+    resource { create(:answer, questionnaire: token.group.resource.questionnaire) }
   end
 end

--- a/lib/tasks/decidim_anonymous_codes_upgrade_tasks.rake
+++ b/lib/tasks/decidim_anonymous_codes_upgrade_tasks.rake
@@ -3,3 +3,12 @@
 Rake::Task["decidim:choose_target_plugins"].enhance do
   ENV["FROM"] = "#{ENV.fetch("FROM", nil)},decidim_anonymous_codes"
 end
+
+namespace :decidim_anonymous_codes do
+  namespace :db do
+    desc "loads all seeds in db/seeds.rb"
+    task seed: :environment do
+      Decidim::AnonymousCodes::Engine.load_seed
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,5 +2,6 @@
 
 require "decidim/core/test/factories"
 require "decidim/surveys/test/factories"
+require "decidim/forms/test/factories"
 require "decidim/proposals/test/factories"
 require "decidim/anonymous_codes/test/factories"

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -7,8 +7,15 @@ require "spec_helper"
 # file should be updated to match any change/bug fix introduced in the core
 checksums = [
   {
-    package: "decidim-core",
+    package: "decidim-surveys",
     files: {
+      "/app/controllers/decidim/surveys/surveys_controller.rb" => "f443ed19838d251fd9d9b960e5908418"
+    }
+  },
+  {
+    package: "decidim-forms",
+    files: {
+      "/app/views/decidim/forms/questionnaires/show.html.erb" => "b54864ffbdaab74bfc82f7b047cbf170"
     }
   }
 ]

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -15,6 +15,7 @@ checksums = [
   {
     package: "decidim-forms",
     files: {
+      "/app/controllers/decidim/forms/concerns/has_questionnaire.rb" => "3e68234b1e489158b3377426236db093",
       "/app/views/decidim/forms/questionnaires/show.html.erb" => "b54864ffbdaab74bfc82f7b047cbf170"
     }
   }

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -14,11 +14,23 @@ module Decidim
         it { expect(described_class.reflect_on_association(:organization).macro).to eq(:belongs_to) }
       end
 
+      it "has an empty counter cache" do
+        expect(group.tokens_count).to eq(0)
+      end
+
       context "when tokens exist" do
         let!(:token) { create(:anonymous_codes_token, group: group) }
 
         it "has an organization" do
           expect(group.organization).to be_a(Decidim::Organization)
+        end
+
+        it "has a counter cache" do
+          expect(group.tokens_count).to eq(1)
+        end
+
+        it "lowers the counter on destroying tokens" do
+          expect { token.destroy }.to change(group, :tokens_count).by(-1)
         end
 
         it "destroys the tokens when destroyed" do

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -151,6 +151,22 @@ module Decidim
             expect { token.destroy }.not_to change(Token, :count)
           end
         end
+
+        context "and another one is created with the same token" do
+          let(:another_token) { build(:anonymous_codes_token, token: token.token, group: token.group) }
+
+          it "cannot be created" do
+            expect { another_token.save! }.to raise_error(ActiveRecord::RecordInvalid)
+          end
+
+          context "and a different group" do
+            let(:another_token) { build(:anonymous_codes_token, token: token.token) }
+
+            it "can be created" do
+              expect { another_token.save! }.to change(Token, :count).by(1)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -13,23 +13,67 @@ module Decidim
         it { expect(described_class.reflect_on_association(:group).macro).to eq(:belongs_to) }
       end
 
-      describe "used?" do
-        context "when usage_count is 0" do
-          it { is_expected.not_to be_used }
+      it { is_expected.not_to be_used }
+
+      it "has an empty counter cache" do
+        expect(token.usage_count).to eq(0)
+      end
+
+      context "when adding an answer" do
+        let(:resource) { create(:answer, questionnaire: token.group.resource.questionnaire) }
+
+        it "can be associated" do
+          expect { token.answers << resource }.to change(token.token_resources, :count).by(1)
         end
 
-        context "when usage_count is 1" do
-          let(:token) { create(:anonymous_codes_token, usage_count: 1) }
+        context "and the answer associated does not belong to the parent questionnaire" do
+          let(:resource) { create(:answer) }
 
-          it { is_expected.to be_used }
-
-          context "when max_reuses is 2" do
-            before do
-              token.group.update!(max_reuses: 2)
-            end
-
-            it { is_expected.not_to be_used }
+          it "cannot be associated" do
+            expect { token.answers << resource }.to raise_error(ActiveRecord::RecordInvalid)
           end
+
+          context "when different resource type" do
+            let(:resource) { create(:questionnaire) }
+
+            it "cannot be associated" do
+              expect { create(:anonymous_codes_token_resource, token: token, resource: resource) }.to raise_error(ActiveRecord::RecordInvalid)
+            end
+          end
+        end
+
+        context "and max uses have been reached" do
+          before do
+            token.answers << resource
+          end
+
+          it "cannot be associated" do
+            expect { token.answers << resource }.to raise_error(ActiveRecord::RecordInvalid)
+          end
+        end
+      end
+
+      context "when resource exists" do
+        let!(:token) { create(:anonymous_codes_token, :used) }
+
+        it { is_expected.to be_used }
+
+        it "has a counter cache" do
+          expect(token.usage_count).to eq(1)
+        end
+
+        it "lowers the counter on removing the resource" do
+          expect(TokenResource.count).to eq(1)
+          expect { token.update!(token_resources: []) }.to change(token, :usage_count).by(-1)
+          expect(TokenResource.count).to eq(0)
+        end
+
+        context "when max_reuses is 2" do
+          before do
+            token.group.update!(max_reuses: 2)
+          end
+
+          it { is_expected.not_to be_used }
         end
       end
 

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -13,6 +13,86 @@ module Decidim
         it { expect(described_class.reflect_on_association(:group).macro).to eq(:belongs_to) }
       end
 
+      describe "used?" do
+        context "when usage_count is 0" do
+          it { is_expected.not_to be_used }
+        end
+
+        context "when usage_count is 1" do
+          let(:token) { create(:anonymous_codes_token, usage_count: 1) }
+
+          it { is_expected.to be_used }
+
+          context "when max_reuses is 2" do
+            before do
+              token.group.update!(max_reuses: 2)
+            end
+
+            it { is_expected.not_to be_used }
+          end
+        end
+      end
+
+      describe "expired?" do
+        context "when expires_at is nil" do
+          it { is_expected.not_to be_expired }
+        end
+
+        context "when expires_at is in the past" do
+          before do
+            token.group.update!(expires_at: 1.minute.ago)
+          end
+
+          it { is_expected.to be_expired }
+        end
+
+        context "when expires_at is in the future" do
+          before do
+            token.group.update!(expires_at: 1.minute.from_now)
+          end
+
+          it { is_expected.not_to be_expired }
+        end
+      end
+
+      describe "active?" do
+        it { is_expected.to be_active }
+
+        context "when inactive" do
+          before do
+            token.group.update!(active: false)
+          end
+
+          it { is_expected.not_to be_active }
+        end
+      end
+
+      describe "available?" do
+        it { is_expected.to be_available }
+
+        context "when used" do
+          let(:token) { create(:anonymous_codes_token, usage_count: 1) }
+
+          it { is_expected.not_to be_available }
+        end
+
+        context "when expired" do
+          before do
+            token.group.update!(expires_at: 1.minute.ago)
+          end
+
+          it { is_expected.not_to be_available }
+        end
+
+        context "when inactive" do
+          before do
+            token.group.update!(active: false)
+          end
+
+          it { is_expected.not_to be_available }
+        end
+      end
+
       context "when created" do
         let!(:token) { create(:anonymous_codes_token) }
 

--- a/spec/system/surveys_answering_spec.rb
+++ b/spec/system/surveys_answering_spec.rb
@@ -56,7 +56,7 @@ describe "Surveys Component Settings", type: :system do
     end
   end
 
-  shared_examples "form is enabled" do
+  shared_examples "form requires codes" do
     it "sends the code and the form" do
       fill_in :token, with: code
       click_button("Continue")
@@ -88,7 +88,7 @@ describe "Surveys Component Settings", type: :system do
   end
 
   shared_examples "can be answered with codes" do
-    it_behaves_like "form is enabled"
+    it_behaves_like "form requires codes"
 
     context "and code group is inactive" do
       let(:active) { false }
@@ -113,7 +113,7 @@ describe "Surveys Component Settings", type: :system do
     context "and group has an expiration" do
       let(:expires) { 1.hour.from_now }
 
-      it_behaves_like "form is enabled"
+      it_behaves_like "form requires codes"
     end
 
     context "and group has expired" do

--- a/spec/system/surveys_answering_spec.rb
+++ b/spec/system/surveys_answering_spec.rb
@@ -8,6 +8,7 @@ describe "Surveys Component Settings", type: :system do
   let(:user) { create :user, :confirmed, organization: organization }
   let(:group) { create :anonymous_codes_group, organization: organization, expires_at: expires, resource: resource, active: active }
   let!(:token) { create :anonymous_codes_token, group: group, usage_count: usage }
+  let!(:another_token) { create :anonymous_codes_token }
   let(:usage) { 0 }
   let(:active) { true }
   let(:expires) { nil }
@@ -122,6 +123,16 @@ describe "Surveys Component Settings", type: :system do
   shared_examples "cannot be answered with bad codes" do
     it "sends the code and fails" do
       fill_in :token, with: "dirty-things"
+      click_button("Continue")
+      expect(page).to have_css(".callout.alert")
+      expect(page).to have_content("The introduced code is invalid.")
+      expect(page).to have_content("Form restricted")
+      expect(page).to have_field("token")
+      expect(page).not_to have_content(first_question.body["en"])
+    end
+
+    it "sends another code and fails" do
+      fill_in :token, with: another_token.token
       click_button("Continue")
       expect(page).to have_css(".callout.alert")
       expect(page).to have_content("The introduced code is invalid.")

--- a/spec/system/surveys_answering_spec.rb
+++ b/spec/system/surveys_answering_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Surveys Component Settings", type: :system do
+  let(:organization) { component.organization }
+  let(:component) { survey.component }
+  let(:user) { create :user, :confirmed, organization: organization }
+  let(:group) { create :anonymous_codes_group, organization: organization, expires_at: expires, resource: resource, active: active }
+  let!(:token) { create :anonymous_codes_token, group: group, usage_count: usage }
+  let(:usage) { 0 }
+  let(:active) { true }
+  let(:expires) { nil }
+  let!(:survey) { create(:survey) }
+  let(:resource) { survey }
+  let(:first_question) { survey.questionnaire.questions.first }
+  let(:code) { token&.token }
+  let(:settings) do
+    {
+      allow_answers: true,
+      allow_unregistered: allow_unregistered
+    }
+  end
+  let(:allow_unregistered) { false }
+
+  def visit_component
+    visit Decidim::EngineRouter.main_proxy(component).survey_path(component.id)
+  end
+
+  before do
+    component.update!(
+      step_settings: {
+        component.participatory_space.active_step.id => settings
+      }
+    )
+
+    switch_to_host(organization.host)
+  end
+
+  shared_examples "form is restricted" do
+    it "shows the restricted message" do
+      expect(page).to have_content("Form restricted")
+      expect(page).to have_field("token")
+    end
+  end
+
+  shared_examples "form is readonly" do
+    it "sends the code" do
+      fill_in :token, with: code
+      click_button("Continue")
+      expect(page).to have_content(first_question.body["en"])
+      expect(page).to have_link("Sign in with your account")
+      expect(page).not_to have_button("Submit")
+    end
+  end
+
+  shared_examples "form is enabled" do
+    it "sends the code and the form" do
+      fill_in :token, with: code
+      click_button("Continue")
+      expect(page).to have_content(first_question.body["en"])
+      expect(page).not_to have_link("Sign in with your account")
+      accept_confirm { click_button "Submit" }
+      expect(page).to have_css(".callout.alert")
+      expect(page).to have_content(first_question.body["en"])
+    end
+  end
+
+  shared_examples "can be answered without codes" do
+    it "sends the form" do
+      expect(page).to have_content(first_question.body["en"])
+      accept_confirm { click_button "Submit" }
+      expect(page).to have_css(".callout.alert")
+      expect(page).to have_content(first_question.body["en"])
+    end
+  end
+
+  shared_examples "can be answered with codes" do
+    it_behaves_like "form is enabled"
+
+    context "and code group is inactive" do
+      let(:active) { false }
+
+      it_behaves_like "can be answered without codes"
+    end
+
+    context "and code re-uses have exceeded" do
+      let(:usage) { 1 }
+
+      it "sends the code and fails" do
+        fill_in :token, with: code
+        click_button("Continue")
+        expect(page).to have_css(".callout.alert")
+        expect(page).to have_content("The introduced code has already been used.")
+        expect(page).to have_content("Form restricted")
+        expect(page).to have_field("token")
+        expect(page).not_to have_content(first_question.body["en"])
+      end
+    end
+
+    context "and group has an expiration" do
+      let(:expires) { 1.hour.from_now }
+
+      it_behaves_like "form is enabled"
+    end
+
+    context "and group has expired" do
+      let(:expires) { 1.minute.ago }
+
+      it "sends the code and fails" do
+        fill_in :token, with: code
+        click_button("Continue")
+        expect(page).to have_css(".callout.alert")
+        expect(page).to have_content("The introduced code has expired.")
+        expect(page).to have_content("Form restricted")
+        expect(page).to have_field("token")
+        expect(page).not_to have_content(first_question.body["en"])
+      end
+    end
+  end
+
+  shared_examples "cannot be answered with bad codes" do
+    it "sends the code and fails" do
+      fill_in :token, with: "dirty-things"
+      click_button("Continue")
+      expect(page).to have_css(".callout.alert")
+      expect(page).to have_content("The introduced code is invalid.")
+      expect(page).to have_content("Form restricted")
+      expect(page).to have_field("token")
+      expect(page).not_to have_content(first_question.body["en"])
+    end
+  end
+
+  context "when user is not logged" do
+    before do
+      visit_component
+    end
+
+    it_behaves_like "form is restricted"
+    it_behaves_like "form is readonly"
+
+    context "and login is not required" do
+      let(:allow_unregistered) { true }
+
+      it_behaves_like "can be answered with codes"
+      it_behaves_like "cannot be answered with bad codes"
+
+      context "and there are no codes required" do
+        let(:resource) { nil }
+
+        it_behaves_like "can be answered without codes"
+      end
+    end
+  end
+
+  context "when user is logged" do
+    before do
+      login_as user, scope: :user
+      visit_component
+    end
+
+    it_behaves_like "form is restricted"
+    it_behaves_like "can be answered with codes"
+    it_behaves_like "cannot be answered with bad codes"
+
+    context "and there are no codes required" do
+      let(:resource) { nil }
+
+      it_behaves_like "can be answered without codes"
+    end
+  end
+end


### PR DESCRIPTION
![image](https://github.com/openpoke/decidim-module-anonymous_codes/assets/1401520/81d4a829-2d99-4db7-8226-702072f1e04c)

- [x] Adds a input to enter de code if not specified in the query_string
- [x] If the code does not belong to the group, ignores it
- [x] if the group is not active, ignores it
- [x] if the group has an expiration date, respects it and shows the user a message
- [x] respects the max reuse property and shows the user a message if exceeded
- [x] Saves the code in session so the user can correct the answers.
- [x] Increments the counter of usage on answering
- [x] Ensure no duplicated codes on the same group

fixes #6 